### PR TITLE
[입출금] 자산 목록 조회

### DIFF
--- a/view/src/app/App.tsx
+++ b/view/src/app/App.tsx
@@ -1,17 +1,44 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useNavigate } from 'react-router-dom';
 import Home from '../pages/Home';
 import MyPage from '../pages/MyPage';
 import SignIn from '../pages/SignIn';
 import SignUp from '../pages/SignUp';
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useAuthActions } from '../shared/store/auth/authActions';
 
 const App = () => {
+  const navigate = useNavigate();
+  const { logout } = useAuthActions();
+  const queryClient = new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error) => {
+        if (error instanceof Error) {
+          if (error.message === '403') {
+            logout();
+            navigate('signin');
+          }
+        }
+      },
+    }),
+    mutationCache: new MutationCache({
+      onError: (error) => {
+        if (error instanceof Error) {
+          if (error.message === '403') {
+            navigate('signin'); // 403 에러 처리
+          }
+        }
+      },
+    }),
+  });
   return (
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/mypage" element={<MyPage />} />
-      <Route path="/signin" element={<SignIn />} />
-      <Route path="/signup" element={<SignUp />} />
-    </Routes>
+    <QueryClientProvider client={queryClient}>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/mypage" element={<MyPage />} />
+        <Route path="/signin" element={<SignIn />} />
+        <Route path="/signup" element={<SignUp />} />
+      </Routes>
+    </QueryClientProvider>
   );
 };
 

--- a/view/src/app/main.tsx
+++ b/view/src/app/main.tsx
@@ -1,21 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import { AuthProvider } from '../shared/store/auth/authContext';
 
-const queryClient = new QueryClient();
-
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </AuthProvider>
-    </QueryClientProvider>
+    <AuthProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/view/src/entities/MyAssetInfo/model/useDeposit.ts
+++ b/view/src/entities/MyAssetInfo/model/useDeposit.ts
@@ -1,30 +1,20 @@
 import { useMutation } from '@tanstack/react-query';
-import depositApi from '../api/depositApi';
-import { useNavigate } from 'react-router-dom';
-import { useAuthActions } from '../../../shared/store/auth/authActions';
+import withdrawApi from '../api/withdrawApi';
 
-const useDeposit = () => {
-  const navigate = useNavigate();
-  const { logout } = useAuthActions();
-
+const useWithdraw = () => {
   return useMutation({
-    mutationFn: depositApi,
+    mutationFn: withdrawApi,
     onSuccess: () => {
-      alert('입금 성공');
+      alert('출금 성공');
     },
     onError: (error: unknown) => {
       if (error instanceof Error) {
-        if (error.message === '403') {
-          logout();
-          navigate('/signin');
-        } else {
-          alert('입금에 실패했습니다. 다시 시도해주세요.');
-        }
+        alert('출금에 실패했습니다. 다시 시도해주세요.');
       } else {
-        alert('입금에 실패했습니다. 다시 시도해주세요.');
+        alert('출금에 실패했습니다. 다시 시도해주세요.');
       }
     },
   });
 };
 
-export default useDeposit;
+export default useWithdraw;

--- a/view/src/entities/MyAssetInfo/model/useWithdraw.ts
+++ b/view/src/entities/MyAssetInfo/model/useWithdraw.ts
@@ -1,12 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
-import { useAuthActions } from '../../../shared/store/auth/authActions';
 import withdrawApi from '../api/withdrawApi';
 
 const useWithdraw = () => {
-  const navigate = useNavigate();
-  const { logout } = useAuthActions();
-
   return useMutation({
     mutationFn: withdrawApi,
     onSuccess: () => {
@@ -14,12 +9,7 @@ const useWithdraw = () => {
     },
     onError: (error: unknown) => {
       if (error instanceof Error) {
-        if (error.message === '403') {
-          logout();
-          navigate('/signin');
-        } else {
-          alert('출금에 실패했습니다. 다시 시도해주세요.');
-        }
+        alert('출금에 실패했습니다. 다시 시도해주세요.');
       } else {
         alert('출금에 실패했습니다. 다시 시도해주세요.');
       }

--- a/view/src/pages/MyPage/api/getAssetsApi.ts
+++ b/view/src/pages/MyPage/api/getAssetsApi.ts
@@ -1,0 +1,19 @@
+const BASE_URL = 'http://localhost:3100';
+
+const getAssetsApi = async () => {
+  const response = await fetch(`${BASE_URL}/api/users/assets`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(response.status.toString());
+  }
+
+  return response.json();
+};
+
+export default getAssetsApi;

--- a/view/src/pages/MyPage/consts/mockData.ts
+++ b/view/src/pages/MyPage/consts/mockData.ts
@@ -3,12 +3,12 @@ export default {
     {
       currencyCode: 'KRW',
       name: '원화',
-      amount: 14000,
+      amount: -1,
     },
     {
       currencyCode: 'BTC',
       name: '비트코인',
-      amount: 17,
+      amount: -1,
     },
     /*
     {

--- a/view/src/pages/MyPage/index.tsx
+++ b/view/src/pages/MyPage/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Header from '../../widgets/Header';
 import Layout from '../../widgets/Layout';
 import MainviewLayout from './UI/MainviewLayout';
@@ -10,17 +10,30 @@ import Title from './UI/Title';
 import MyAssetList from '../../entities/MyAssetList';
 
 import CATEGORY from './consts/category';
-import assetList from './consts/mockData';
 import MyAssetInfo from '../../entities/MyAssetInfo';
+import useGetAssets from './model/useGetAssets';
+import { useNavigate } from 'react-router-dom';
 
 const Home = () => {
+  const navigate = useNavigate();
   const [selectedCateIdx, setSelectedCateIdx] = useState(0);
   const [selectedAssetIdx, setSelectedAssetIdx] = useState(0);
+
+  const { data: assetList, isError, error } = useGetAssets();
 
   const moveCategory = (categoryIdx: number) => {
     setSelectedCateIdx(categoryIdx);
   };
 
+  useEffect(() => {
+    if (isError && error instanceof Response && error.status === 403) {
+      navigate('/signin');
+    }
+  }, [isError, error, navigate]);
+
+  if (!assetList) {
+    return <p className="text-text-light">Loading or no data available</p>;
+  }
   return (
     <div>
       <Header />
@@ -40,14 +53,18 @@ const Home = () => {
 
         <MainviewLayout>
           <Title content={CATEGORY[selectedCateIdx]} />
-          <MyAssetList
-            assetList={assetList.assets}
-            setSelectedAssetIdx={setSelectedAssetIdx}
-          ></MyAssetList>
-          <MyAssetInfo
-            currencyCode={assetList.assets[selectedAssetIdx].currencyCode}
-            amount={assetList.assets[selectedAssetIdx].amount}
-          ></MyAssetInfo>
+          {selectedCateIdx === 1 && (
+            <div>
+              <MyAssetList
+                assetList={assetList.assets}
+                setSelectedAssetIdx={setSelectedAssetIdx}
+              ></MyAssetList>
+              <MyAssetInfo
+                currencyCode={assetList.assets[selectedAssetIdx].currencyCode}
+                amount={assetList.assets[selectedAssetIdx].amount}
+              ></MyAssetInfo>
+            </div>
+          )}
         </MainviewLayout>
       </Layout>
     </div>

--- a/view/src/pages/MyPage/index.tsx
+++ b/view/src/pages/MyPage/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Header from '../../widgets/Header';
 import Layout from '../../widgets/Layout';
 import MainviewLayout from './UI/MainviewLayout';
@@ -12,28 +12,17 @@ import MyAssetList from '../../entities/MyAssetList';
 import CATEGORY from './consts/category';
 import MyAssetInfo from '../../entities/MyAssetInfo';
 import useGetAssets from './model/useGetAssets';
-import { useNavigate } from 'react-router-dom';
 
 const Home = () => {
-  const navigate = useNavigate();
   const [selectedCateIdx, setSelectedCateIdx] = useState(0);
   const [selectedAssetIdx, setSelectedAssetIdx] = useState(0);
 
-  const { data: assetList, isError, error } = useGetAssets();
+  const { data: assetList } = useGetAssets();
 
   const moveCategory = (categoryIdx: number) => {
     setSelectedCateIdx(categoryIdx);
   };
 
-  useEffect(() => {
-    if (isError && error instanceof Response && error.status === 403) {
-      navigate('/signin');
-    }
-  }, [isError, error, navigate]);
-
-  if (!assetList) {
-    return <p className="text-text-light">Loading or no data available</p>;
-  }
   return (
     <div>
       <Header />
@@ -53,7 +42,7 @@ const Home = () => {
 
         <MainviewLayout>
           <Title content={CATEGORY[selectedCateIdx]} />
-          {selectedCateIdx === 1 && (
+          {selectedCateIdx === 1 && assetList && (
             <div>
               <MyAssetList
                 assetList={assetList.assets}

--- a/view/src/pages/MyPage/model/useGetAssets.ts
+++ b/view/src/pages/MyPage/model/useGetAssets.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import getAssetsApi from '../api/getAssetsApi';
+
+const useGetAssets = () => {
+  return useQuery({
+    queryKey: ['assets'],
+    queryFn: getAssetsApi,
+    retry: 1,
+  });
+};
+
+export default useGetAssets;


### PR DESCRIPTION
## 📚 이슈 번호
- close #4 

## ✅ 작업 내용
- [x] 자산 목록 띄우기
- [x] 403 에러 시에 로그인 페이지 이동

## 🔥 트러블 슈팅
### useQuery의 onError가 deprecated 되었다...
- 해결
전역 에러 관리로 처리해주었다.
> 이 방법으로 다른 에러 처리도 고도화 할 예정
```
  const queryClient = new QueryClient({
    queryCache: new QueryCache({
      onError: (error) => {
        if (error instanceof Error) {
          if (error.message === '403') {
            logout();
            navigate('signin');
          }
        }
      },
    }),
    mutationCache: new MutationCache({
      onError: (error) => {
        if (error instanceof Error) {
          if (error.message === '403') {
            navigate('signin'); // 403 에러 처리
          }
        }
      },
    }),
  });
```

## 🖋️ 학습 자료
(... 문서 작성 예정)

[TanStack Query v5를 사용해 API 호출 시 발생한 에러 핸들링하기 (+ 네트워크 에러)](https://velog.io/@ebokyung/TanStack-Query-V5%EC%97%90%EC%84%9C-%EC%97%90%EB%9F%AC-%ED%95%B8%EB%93%A4%EB%A7%81%ED%95%98%EA%B8%B0#-api-%ED%98%B8%EC%B6%9C-%EC%8B%9C-%EB%B0%9C%EC%83%9D%ED%95%98%EB%8A%94-%EC%97%90%EB%9F%AC-%ED%95%B8%EB%93%A4%EB%A7%81)
[React Query Error Handling](https://tkdodo.eu/blog/react-query-error-handling)
[TanStack Query V5 공통 에러 처리(Feat. onError, Error Boundary)](https://velog.io/@ses2201/TanStack-Query-V5-%EA%B3%B5%ED%86%B5-%EC%97%90%EB%9F%AC-%EC%B2%98%EB%A6%ACFeat.-onError-Error-Boundary)
[tanstack Query 공식 문서](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclient)
[[번역] React Query API의 의도된 중단](https://velog.io/@cnsrn1874/breaking-react-querys-api-on-purpose)

