### PR TITLE
[차트] 호가창 view 구현

### DIFF
--- a/view/src/entities/OrderBook/UI/OrderItem.tsx
+++ b/view/src/entities/OrderBook/UI/OrderItem.tsx
@@ -1,0 +1,27 @@
+import { OrderType } from '../model/OrderType';
+
+interface OrderItemProps {
+  setOrderPrice: React.Dispatch<React.SetStateAction<number>>;
+  orderInfo: OrderType;
+}
+
+const OrderItem: React.FC<OrderItemProps> = ({ setOrderPrice, orderInfo }) => {
+  const { price, priceChangeRate, amount } = orderInfo;
+  const handleClick = () => {
+    setOrderPrice(price);
+  };
+  return (
+    <div
+      className="h-[2.125rem] flex justify-between items-center cursor-pointer px-[3rem] border-y-[1px] border-border-default"
+      onClick={handleClick}
+    >
+      <div className="flex gap-[2rem] ">
+        <div className="text-display-bold-16">{price.toLocaleString()}</div>
+        <div>{priceChangeRate}</div>
+      </div>
+      <div className="text-text-light">{amount}</div>
+    </div>
+  );
+};
+
+export default OrderItem;

--- a/view/src/entities/OrderBook/index.tsx
+++ b/view/src/entities/OrderBook/index.tsx
@@ -1,0 +1,40 @@
+import { OrderType } from './model/OrderType';
+import OrderItem from './UI/OrderItem';
+
+interface OrderBookProps {
+  priceChangeRate: number;
+  setOrderPrice: React.Dispatch<React.SetStateAction<number>>;
+  orderBook: {
+    currentPrice: number;
+    sell: OrderType[];
+    buy: OrderType[];
+  };
+}
+
+const OrderBook: React.FC<OrderBookProps> = ({ priceChangeRate, setOrderPrice, orderBook }) => {
+  return (
+    <div className="w-[31rem] h-[24rem] relative border-[1px] bg-surface-default border-border-default">
+      <div className="w-full text-positive absolute bottom-[212px]">
+        {orderBook.sell &&
+          orderBook.sell.map((o) => {
+            return <OrderItem key={o.price} setOrderPrice={setOrderPrice} orderInfo={o} />;
+          })}
+      </div>
+
+      <div
+        className={`w-full h-[2.75rem] absolute top-[170px] flex items-center px-[3rem] border-y-[1px] border-border-default text-display-bold-24 ${priceChangeRate > 0 ? 'text-positive' : 'text-negative'}`}
+      >
+        {orderBook.currentPrice.toLocaleString()}
+      </div>
+
+      <div className="w-full text-negative absolute top-[214px]">
+        {orderBook.buy &&
+          orderBook.buy.map((o) => {
+            return <OrderItem key={o.price} setOrderPrice={setOrderPrice} orderInfo={o} />;
+          })}
+      </div>
+    </div>
+  );
+};
+
+export default OrderBook;

--- a/view/src/entities/OrderBook/model/OrderType.ts
+++ b/view/src/entities/OrderBook/model/OrderType.ts
@@ -1,0 +1,5 @@
+export interface OrderType {
+  price: number;
+  priceChangeRate: number;
+  amount: number;
+}

--- a/view/src/pages/Home/UI/Title.tsx
+++ b/view/src/pages/Home/UI/Title.tsx
@@ -1,0 +1,35 @@
+import up from '../../../shared/images/up.svg';
+import down from '../../../shared/images/down.svg';
+
+interface TitleProps {
+  currentPrice: { price: number; priceChangeAmount: number; priceChangeRate: number };
+}
+
+const Title: React.FC<TitleProps> = ({ currentPrice }) => {
+  return (
+    <div className="w-full h-[5.5rem] flex justify-between items-center px-[2.5rem]">
+      <div className="text-display-bold-32">비트코인</div>
+      <div
+        className={`text-available-medium-14 ${currentPrice.priceChangeAmount > 0 ? 'text-positive' : 'text-negative'}`}
+      >
+        <div className="h-[2.25rem]">
+          <span className="text-display-bold-28">{currentPrice.price.toLocaleString()}</span>
+          KRW
+        </div>
+        <div className="flex">
+          {currentPrice.priceChangeRate}%
+          <img
+            src={`${currentPrice.priceChangeAmount > 0 ? up : down}`}
+            alt="mark"
+            height={14}
+            width={14}
+            style={{ marginLeft: '0.5rem' }}
+          />
+          {currentPrice.priceChangeAmount.toLocaleString()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Title;

--- a/view/src/pages/Home/consts/currentPriceMockData.ts
+++ b/view/src/pages/Home/consts/currentPriceMockData.ts
@@ -1,0 +1,5 @@
+export default {
+  price: 24000000,
+  priceChangeAmount: -560000,
+  priceChangeRate: -0.6,
+};

--- a/view/src/pages/Home/consts/orderBookMockData.ts
+++ b/view/src/pages/Home/consts/orderBookMockData.ts
@@ -1,0 +1,57 @@
+export default {
+  currentPrice: 24000000,
+  sell: [
+    {
+      price: 24010000,
+      priceChangeRate: -0.25,
+      amount: 5,
+    },
+    {
+      price: 24020000,
+      priceChangeRate: -0.15,
+      amount: 10,
+    },
+    {
+      price: 24030000,
+      priceChangeRate: -0.05,
+      amount: 8,
+    },
+    {
+      price: 24040000,
+      priceChangeRate: 0.05,
+      amount: 12,
+    },
+    {
+      price: 24050000,
+      priceChangeRate: 0.15,
+      amount: 6,
+    },
+  ],
+  buy: [
+    {
+      price: 23990000,
+      priceChangeRate: 0.05,
+      amount: 7,
+    },
+    {
+      price: 23980000,
+      priceChangeRate: 0.15,
+      amount: 12,
+    },
+    {
+      price: 23970000,
+      priceChangeRate: 0.25,
+      amount: 6,
+    },
+    {
+      price: 23960000,
+      priceChangeRate: 0.35,
+      amount: 10,
+    },
+    {
+      price: 23950000,
+      priceChangeRate: 0.45,
+      amount: 15,
+    },
+  ],
+};

--- a/view/src/pages/Home/index.tsx
+++ b/view/src/pages/Home/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Chart from '../../entities/Chart';
+import OrderBook from '../../entities/OrderBook';
 import Header from '../../widgets/Header';
 import Layout from '../../widgets/Layout';
 import d1candleData from './consts/d1candleData';
@@ -9,6 +10,7 @@ import Title from './UI/Title';
 import generateCandleData from './lib/generateCandleData';
 import { ChartTimeScaleType } from '../../shared/types/ChartTimeScaleType';
 import currentPriceMockData from './consts/currentPriceMockData';
+import orderBookMockData from './consts/orderBookMockData';
 
 const timeScaleMap = {
   '1s': 1000,
@@ -24,6 +26,9 @@ const timeScaleMap = {
 const Home = () => {
   const [candleData, setCandleData] = useState(d1candleData);
   const [selectedTimeScale, setSelectedTimeScale] = useState<ChartTimeScaleType>('1d'); // 타입 지정
+  const [orderPrice, setOrderPrice] = useState<number>(
+    orderBookMockData.buy[orderBookMockData.buy.length - 1].price
+  );
 
   useEffect(() => {
     const baseDate = new Date('2024-01-01T10:00:00');
@@ -53,6 +58,11 @@ const Home = () => {
         />
         <Chart data={candleData} scaleType={selectedTimeScale} />
         <button onClick={handleButtonClick}>Generate More Data</button>
+        <OrderBook
+          priceChangeRate={currentPriceMockData.priceChangeRate}
+          setOrderPrice={setOrderPrice}
+          orderBook={orderBookMockData}
+        />
       </Layout>
     </div>
   );

--- a/view/src/pages/Home/index.tsx
+++ b/view/src/pages/Home/index.tsx
@@ -3,9 +3,12 @@ import Chart from '../../entities/Chart';
 import Header from '../../widgets/Header';
 import Layout from '../../widgets/Layout';
 import d1candleData from './consts/d1candleData';
-import generateCandleData from './lib/generateCandleData';
 import TimeScaleSelector from './UI/TimeScaleSelector';
+import Title from './UI/Title';
+
+import generateCandleData from './lib/generateCandleData';
 import { ChartTimeScaleType } from '../../shared/types/ChartTimeScaleType';
+import currentPriceMockData from './consts/currentPriceMockData';
 
 const timeScaleMap = {
   '1s': 1000,
@@ -43,6 +46,7 @@ const Home = () => {
     <div>
       <Header />
       <Layout paddingX="px-[22vw]" flex={false}>
+        <Title currentPrice={currentPriceMockData} />
         <TimeScaleSelector
           selectedTimeScale={selectedTimeScale}
           setSelectedTimeScale={setSelectedTimeScale}

--- a/view/src/shared/images/down.svg
+++ b/view/src/shared/images/down.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#FF5252" width="800px" height="800px" viewBox="0 0 24 24" id="down-direction-2" data-name="Flat Color" xmlns="http://www.w3.org/2000/svg" class="icon flat-color"><path id="primary" d="M21.71,8.41,18.88,5.59a1,1,0,0,0-1.42,0L12,11.05,6.54,5.59a1,1,0,0,0-1.42,0L2.29,8.42a1,1,0,0,0,0,1.41l8.29,8.29a2,2,0,0,0,2.84,0l8.29-8.3A1,1,0,0,0,22,9.11,1,1,0,0,0,21.71,8.41Z" style="fill: #FF5252"></path></svg>

--- a/view/src/shared/images/up.svg
+++ b/view/src/shared/images/up.svg
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#00E676" width="800px" height="800px" viewBox="0 0 24 24" id="down-direction-2" data-name="Flat Color" xmlns="http://www.w3.org/2000/svg" class="icon flat-color" transform="matrix(1, 0, 0, -1, 0, 0)">
+
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+
+<g id="SVGRepo_iconCarrier">
+
+<path id="primary" d="M21.71,8.41,18.88,5.59a1,1,0,0,0-1.42,0L12,11.05,6.54,5.59a1,1,0,0,0-1.42,0L2.29,8.42a1,1,0,0,0,0,1.41l8.29,8.29a2,2,0,0,0,2.84,0l8.29-8.3A1,1,0,0,0,22,9.11,1,1,0,0,0,21.71,8.41Z" style="fill: #00E676;"/>
+
+</g>
+
+</svg>

--- a/view/tailwind.config.js
+++ b/view/tailwind.config.js
@@ -4,7 +4,8 @@ module.exports = {
   theme: {
     extend: {
       fontSize: {
-        'display-bold-32': ['2rem', { lineHeight: 'auto', fontWeight: '700' }], // 24px Bold
+        'display-bold-32': ['2rem', { lineHeight: 'auto', fontWeight: '700' }], // 32px Bold
+        'display-bold-28': ['1.75rem', { lineHeight: 'auto', fontWeight: '700' }], // 28px Bold
         'display-bold-24': ['1.5rem', { lineHeight: 'auto', fontWeight: '700' }], // 24px Bold
         'display-bold-20': ['1.25em', { lineHeight: 'auto', fontWeight: '700' }], // 20px Bold
         'display-bold-16': ['1rem', { lineHeight: 'auto', fontWeight: '700' }], // 16px Bold


### PR DESCRIPTION
## 📚 이슈 번호
- close #100 

## ✅ 작업 내용
- [x] 매수 컴포넌트
- [x] 매도 컴포넌트
- [x] 현재 시세
- [x] 상단 타이틀
- [x] 매수, 매도 주문에 상관 없이 컴포넌트 위치 고정
- [x] 매수, 매도 주문 클릭 시 orderPrice 변경

![Image](https://github.com/user-attachments/assets/e35542c8-7c9a-447f-b871-c0bc01b6d021)
![Image](https://github.com/user-attachments/assets/2d2398db-0fc2-411b-a206-fa86949a1197)

## 🔥 트러블 슈팅
### 매수, 시세, 매도 컴포넌트 위치 고정하기
- 문제 상황
매수, 매도 주문이 0-5개가 들어올 수 있다. 여기서 시세 컴포넌트를 중간에 고정하고자 함

- 해결 방법
`relative`와 `absolute`를 이용해 각 컴포넌트의 레이아웃 위치를 고정
```

const OrderBook: React.FC<OrderBookProps> = ({ priceChangeRate, setOrderPrice, orderBook }) => {
  return (
    <div className="w-[31rem] h-[24rem] relative border-[1px] bg-surface-default border-border-default">
      <div className="w-full text-positive absolute bottom-[212px]">
   
      </div>

      <div
        className={`w-full h-[2.75rem] absolute top-[170px] flex items-center px-[3rem] border-y-[1px] border-border-default text-display-bold-24 ${priceChangeRate > 0 ? 'text-positive' : 'text-negative'}`}
      >
        {orderBook.currentPrice.toLocaleString()}
      </div>

      <div className="w-full text-negative absolute top-[214px]">

      </div>
    </div>
  );
};

```


