### PR TITLE
[체결] 체결 내역 조회 구현

### DIFF
--- a/microservice/apps/trade/prisma/schema.prisma
+++ b/microservice/apps/trade/prisma/schema.prisma
@@ -37,10 +37,16 @@ model sellOrder {
 
 model trade {
   tradeId     String   @id @default(cuid()) @map("_id")
+  buyerId     String   @map("buyer_id")
   buyOrderId  String   @map("buy_order_id")
+  sellerId    String   @map("seller_id")
   sellOrderId String   @map("sell_order_id")
   coinCode    String   @map("coin_code")
   price       String
   quantity    String
   tradedAt    DateTime @default(now()) @map("traded_at")
+
+  @@index(buyerId)
+  @@index(sellerId)
+  @@index([tradedAt(sort: Desc)])
 }

--- a/microservice/apps/transaction/prisma/schema.prisma
+++ b/microservice/apps/transaction/prisma/schema.prisma
@@ -157,12 +157,16 @@ model candle01Month {
 
 model trade {
   tradeId     String   @id @default(cuid()) @map("_id")
+  buyerId     String   @map("buyer_id")
   buyOrderId  String   @map("buy_order_id")
+  sellerId    String   @map("seller_id")
   sellOrderId String   @map("sell_order_id")
   coinCode    String   @map("coin_code")
   price       String
   quantity    String
   tradedAt    DateTime @default(now()) @map("traded_at")
 
+  @@index(buyerId)
+  @@index(sellerId)
   @@index([tradedAt(sort: Desc)])
 }

--- a/microservice/apps/transaction/src/dto/order.pending.response.dto.ts
+++ b/microservice/apps/transaction/src/dto/order.pending.response.dto.ts
@@ -4,9 +4,9 @@ export class OrderPendingResponseDto {
   historyId: string;
   orderType: OrderType;
   coinCode: string;
-  price: string;
-  quantity: string;
-  unfilledAmount: string;
+  price: number;
+  quantity: number;
+  unfilledAmount: number;
   createdAt: Date;
 
   constructor(
@@ -21,9 +21,9 @@ export class OrderPendingResponseDto {
     this.historyId = historyId;
     this.orderType = orderType;
     this.coinCode = coinCode;
-    this.price = price;
-    this.quantity = quantity;
-    this.unfilledAmount = unfilledAmount;
+    this.price = Number(price);
+    this.quantity = Number(quantity);
+    this.unfilledAmount = Number(unfilledAmount);
     this.createdAt = createdAt;
   }
 }

--- a/microservice/apps/transaction/src/dto/trade.get.response.dto.ts
+++ b/microservice/apps/transaction/src/dto/trade.get.response.dto.ts
@@ -1,0 +1,28 @@
+import { OrderType } from '@app/common/enums/order-type.enum';
+
+export class TradeGetResponseDto {
+  tradeId: string;
+  orderType: OrderType;
+  coinCode: string;
+  price: number;
+  quantity: number;
+  totalAmount: number;
+  tradedAt: Date;
+
+  constructor(
+    tradeId: string,
+    orderType: OrderType,
+    coinCode: string,
+    price: string,
+    quantity: string,
+    tradedAt: Date,
+  ) {
+    this.tradeId = tradeId;
+    this.orderType = orderType;
+    this.coinCode = coinCode;
+    this.price = Number(price);
+    this.quantity = Number(quantity);
+    this.totalAmount = this.price * this.quantity;
+    this.tradedAt = tradedAt;
+  }
+}

--- a/microservice/apps/transaction/src/transaction.controller.ts
+++ b/microservice/apps/transaction/src/transaction.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Query,
   Get,
+  BadRequestException,
 } from '@nestjs/common';
 import { TransactionService } from './transaction.service';
 import { AuthenticatedGuard } from '@app/session/guard/authenticated.guard';
@@ -35,6 +36,10 @@ export class TransactionController {
       buyLimitRequest.amount,
       buyLimitRequest.price,
     );
+
+    if (orderRequest.amount <= 0)
+      throw new BadRequestException('주문 수량은 1개 이상이어야 합니다.');
+
     const response = await this.transactionOrderService.makeBuyOrder(orderRequest);
 
     await this.transactionService.registerBuyOrder(orderRequest, response);
@@ -51,6 +56,10 @@ export class TransactionController {
       sellLimitRequest.amount,
       sellLimitRequest.price,
     );
+
+    if (orderRequest.amount <= 0)
+      throw new BadRequestException('주문 수량은 1개 이상이어야 합니다.');
+
     const response = await this.transactionOrderService.makeSellOrder(orderRequest);
 
     await this.transactionService.registerSellOrder(orderRequest, response);

--- a/microservice/apps/transaction/src/transaction.controller.ts
+++ b/microservice/apps/transaction/src/transaction.controller.ts
@@ -76,4 +76,11 @@ export class TransactionController {
     const userId = req.user.userId;
     return await this.transactionService.getPending(userId);
   }
+
+  @Get()
+  @UseGuards(AuthenticatedGuard)
+  async getOrders(@Request() req, @Query('id') id?: string) {
+    const userId = String(req.user.userId);
+    return await this.transactionService.getOrders(userId, id);
+  }
 }

--- a/microservice/apps/transaction/src/transaction.repository.ts
+++ b/microservice/apps/transaction/src/transaction.repository.ts
@@ -138,4 +138,28 @@ export class TransactionRepository {
       },
     });
   }
+
+  async getTradeOrders(userId: string, lastId?: string) {
+    return await this.prisma.trade.findMany({
+      select: {
+        tradeId: true,
+        buyerId: true,
+        buyOrderId: true,
+        sellerId: true,
+        sellOrderId: true,
+        coinCode: true,
+        price: true,
+        quantity: true,
+        tradedAt: true,
+      },
+      where: {
+        OR: [{ buyerId: userId }, { sellerId: userId }],
+        ...(lastId ? { tradeId: { gte: lastId } } : {}),
+      },
+      orderBy: {
+        tradedAt: 'desc',
+      },
+      take: 31,
+    });
+  }
 }

--- a/microservice/apps/transaction/src/transaction.repository.ts
+++ b/microservice/apps/transaction/src/transaction.repository.ts
@@ -154,7 +154,7 @@ export class TransactionRepository {
       },
       where: {
         OR: [{ buyerId: userId }, { sellerId: userId }],
-        ...(lastId ? { tradeId: { gte: lastId } } : {}),
+        ...(lastId ? { tradeId: { lte: lastId } } : {}),
       },
       orderBy: {
         tradedAt: 'desc',

--- a/microservice/libs/grpc/src/dto/trade.history.request.dto.ts
+++ b/microservice/libs/grpc/src/dto/trade.history.request.dto.ts
@@ -1,9 +1,11 @@
 export class TradeHistoryRequestDto {
   historyId: string;
+  userId: string;
   remain: number;
 
-  constructor(historyId: string, remain: number) {
+  constructor(historyId: string, userId: string, remain: number) {
     this.historyId = historyId;
+    this.userId = userId;
     this.remain = remain;
   }
 }


### PR DESCRIPTION
## 📚 이슈 번호
- close #106 
- close #107 
- close #108 

## ✅ 작업 내용
- 체결 내역 조회
  - id로 체결 내역 30개 씩 조회 -> 본인이 사고 팔았다면 최대 60개 조회
- 미체결 조회 price number로 변경
- 매수 매도 주문 시 0개 이하의 주문은 400 에러 발생

## 🔥 트러블 슈팅

## 🖋️ 학습 자료

## 🐝 비고