### PR TITLE
[체결] 매수 매도 접수 후 buy_order, sell_order에 만들어지는 순서를 큐에서 진행하도록 변경

### DIFF
--- a/microservice/apps/trade/src/trade.processor.ts
+++ b/microservice/apps/trade/src/trade.processor.ts
@@ -17,11 +17,11 @@ export class TradeProcessor extends WorkerHost {
 
     switch (job.name) {
       case OrderType.BUY:
-        await this.tradeService.tradeBuyOrder(job.data.historyId);
+        await this.tradeService.processTrade(job.name, job.data);
         break;
 
       case OrderType.SELL:
-        await this.tradeService.tradeSellOrder(job.data.historyId);
+        await this.tradeService.processTrade(job.name, job.data);
         break;
 
       case OrderType.CANCELED:

--- a/microservice/apps/trade/src/trade.processor.ts
+++ b/microservice/apps/trade/src/trade.processor.ts
@@ -17,11 +17,11 @@ export class TradeProcessor extends WorkerHost {
 
     switch (job.name) {
       case OrderType.BUY:
-        await this.tradeService.processTrade(job.name, job.data);
+        await this.tradeService.processTrade(job.name, job.data.trade);
         break;
 
       case OrderType.SELL:
-        await this.tradeService.processTrade(job.name, job.data);
+        await this.tradeService.processTrade(job.name, job.data.trade);
         break;
 
       case OrderType.CANCELED:

--- a/microservice/apps/trade/src/trade.service.ts
+++ b/microservice/apps/trade/src/trade.service.ts
@@ -6,10 +6,10 @@ import { TradeBuyerRequestDto } from '@app/grpc/dto/trade.buyer.request.dto';
 import { TradeSellerRequestDto } from '@app/grpc/dto/trade.seller.request.dto';
 import { TradeRequestDto } from '@app/grpc/dto/trade.request.dto';
 import { TradeBalanceService } from './trade.balance.service';
-import { formatFixedPoint } from '@app/common/utils/number.format.util';
 import { TradeCancelRequestDto } from '@app/grpc/dto/trade.cancel.request.dto';
 import { BuyOrder } from './dto/trade.buy.order.type';
 import { SellOrder } from './dto/trade.sell.order.type';
+import { TradeOrder } from '@app/grpc/dto/trade.order.dto';
 
 const BATCH_SIZE = 30;
 
@@ -20,23 +20,9 @@ export class TradeService {
     private tradeBalanceService: TradeBalanceService,
   ) {}
 
-  async tradeBuyOrder(historyId: string) {
-    const buyOrder = await this.tradeRepository.findBuyOrderByHistoryId(historyId);
-    if (!buyOrder) return;
-
-    await this.processTrade(OrderType.BUY, buyOrder, buyOrder.remainingQuote);
-  }
-
-  async tradeSellOrder(historyId: string) {
-    const sellOrder = await this.tradeRepository.findSellOrderByHistoryId(historyId);
-    if (!sellOrder) return;
-
-    await this.processTrade(OrderType.SELL, sellOrder, sellOrder.remainingBase);
-  }
-
-  async processTrade(type: OrderType, current: BuyOrder | SellOrder, amount: string) {
+  async processTrade(type: OrderType, current: TradeOrder) {
     const { coinCode, price } = current;
-    let remain = Number(amount);
+    let remain = current.originalQuote;
     let offset = 0;
 
     const getOrders = this.getOrdersFetcher(type);
@@ -48,25 +34,19 @@ export class TradeService {
       for (const order of orders) {
         if (remain === 0) break;
 
-        const { quantity, opposite } = this.calculateTrade(type, order, remain);
-        remain -= quantity;
+        const { quantity, opposite } = this.calculateTrade(order, remain);
+        remain -= quantity; // 계산 문제 발생 가능
 
-        const tradePrice = Number(order.price);
+        const tradePrice = order.price;
         await this.settleTransaction(type, current, order, tradePrice, quantity);
 
-        await this.updateOrderAndTradeLog(
-          type,
-          current,
-          opposite,
-          coinCode,
-          tradePrice,
-          quantity,
-          remain,
-        );
+        await this.updateOrderAndTradeLog(type, current, opposite, coinCode, order.price, quantity);
       }
 
       offset += BATCH_SIZE;
     }
+
+    await this.createTradeOrder(type, current, remain);
   }
 
   getOrdersFetcher(type: OrderType) {
@@ -77,7 +57,7 @@ export class TradeService {
           this.tradeRepository.findBuyOrders(coinCode, price, offset, batchSize);
   }
 
-  calculateTrade(type: OrderType, order: BuyOrder | SellOrder, remain: number) {
+  calculateTrade(order: BuyOrder | SellOrder, remain: number) {
     let quantity: number;
     const availableAmount = Number(this.getRemain(order));
 
@@ -107,23 +87,23 @@ export class TradeService {
 
   async settleTransaction(
     type: OrderType,
-    current: BuyOrder | SellOrder,
+    current: TradeOrder,
     order: BuyOrder | SellOrder,
-    tradePrice: number,
+    tradePrice: string,
     quantity: number,
   ) {
     const buyer = new TradeBuyerRequestDto(
       type === OrderType.BUY ? current.userId : order.userId,
       current.coinCode,
-      type === OrderType.BUY ? Number(current.price) : Number(order.price),
+      type === OrderType.BUY ? current.price : order.price,
       tradePrice,
-      quantity,
+      String(quantity),
     );
     const seller = new TradeSellerRequestDto(
       type === OrderType.BUY ? order.userId : current.userId,
       current.coinCode,
       tradePrice,
-      quantity,
+      String(quantity),
     );
     const tradeRequest = new TradeRequestDto(buyer, seller);
     await this.tradeBalanceService.settleTransaction(tradeRequest);
@@ -131,12 +111,11 @@ export class TradeService {
 
   async updateOrderAndTradeLog(
     type: OrderType,
-    current: BuyOrder | SellOrder,
+    current: TradeOrder,
     opposite: TradeHistoryRequestDto,
     coinCode: string,
-    tradePrice: number,
+    tradePrice: string,
     quantity: number,
-    remain: number,
   ) {
     const trade = {
       buyerId: type === OrderType.BUY ? current.userId : opposite.userId,
@@ -144,14 +123,24 @@ export class TradeService {
       sellerId: type === OrderType.BUY ? opposite.userId : current.userId,
       sellOrderId: type === OrderType.BUY ? opposite.historyId : current.historyId,
       coinCode: coinCode,
-      price: formatFixedPoint(tradePrice),
+      price: tradePrice,
       quantity: String(quantity),
     };
 
     if (type === OrderType.BUY) {
-      await this.tradeRepository.tradeBuyOrder(opposite, remain, current.historyId, trade);
+      await this.tradeRepository.tradeBuyOrder(opposite, trade);
     } else {
-      await this.tradeRepository.tradeSellOrder(opposite, remain, current.historyId, trade);
+      await this.tradeRepository.tradeSellOrder(opposite, trade);
+    }
+  }
+
+  async createTradeOrder(type: OrderType, current: TradeOrder, remain: number) {
+    if (remain === 0) return;
+
+    if (type === OrderType.BUY) {
+      await this.tradeRepository.createBuyOrder(current, remain);
+    } else {
+      await this.tradeRepository.createSellOrder(current, remain);
     }
   }
 

--- a/microservice/apps/transaction/src/transaction.controller.ts
+++ b/microservice/apps/transaction/src/transaction.controller.ts
@@ -17,6 +17,7 @@ import { TransactionOrderService } from './transaction.order.service';
 import { OrderRequestDto } from '@app/grpc/dto/order.request.dto';
 import { OrderType } from '@app/common/enums/order-type.enum';
 import { TransactionQueueService } from './transaction.queue.service';
+import { TradeOrder } from '@app/grpc/dto/trade.order.dto';
 
 @Controller('api/orders')
 export class TransactionController {
@@ -41,9 +42,10 @@ export class TransactionController {
       throw new BadRequestException('주문 수량은 1개 이상이어야 합니다.');
 
     const response = await this.transactionOrderService.makeBuyOrder(orderRequest);
+    this.transactionService.validateOrderResponse(response);
 
-    await this.transactionService.registerBuyOrder(orderRequest, response);
-    return await this.transactionQueueService.addQueue(OrderType.BUY, response.historyId);
+    const trade = new TradeOrder(response.historyId, orderRequest);
+    return await this.transactionQueueService.addQueue(OrderType.BUY, trade);
   }
 
   @Post('/limit/sell')
@@ -61,9 +63,10 @@ export class TransactionController {
       throw new BadRequestException('주문 수량은 1개 이상이어야 합니다.');
 
     const response = await this.transactionOrderService.makeSellOrder(orderRequest);
+    this.transactionService.validateOrderResponse(response);
 
-    await this.transactionService.registerSellOrder(orderRequest, response);
-    return await this.transactionQueueService.addQueue(OrderType.SELL, response.historyId);
+    const trade = new TradeOrder(response.historyId, orderRequest);
+    return await this.transactionQueueService.addQueue(OrderType.SELL, trade);
   }
 
   @Delete('/:historyId')

--- a/microservice/apps/transaction/src/transaction.queue.service.ts
+++ b/microservice/apps/transaction/src/transaction.queue.service.ts
@@ -2,13 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { OrderType } from '@app/common/enums/order-type.enum';
+import { TradeOrder } from '@app/grpc/dto/trade.order.dto';
 
 @Injectable()
 export class TransactionQueueService {
   constructor(@InjectQueue('trade') private queue: Queue) {}
 
-  async addQueue(name: string, historyId: string) {
-    await this.queue.add(name, { historyId: historyId }, { jobId: `${name}-${historyId}` });
+  async addQueue(name: string, trade: TradeOrder) {
+    await this.queue.add(name, { trade }, { jobId: `${name}-${trade.historyId}` });
   }
 
   async addCancelQueue(userId: bigint, historyId: string, orderType: OrderType) {

--- a/microservice/apps/transaction/src/transaction.repository.ts
+++ b/microservice/apps/transaction/src/transaction.repository.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@app/prisma';
-import { OrderRequestDto } from '@app/grpc/dto/order.request.dto';
 import { TimeScale } from '@app/common/enums/chart-timescale.enum';
-import { formatFixedPoint } from '@app/common/utils/number.format.util';
 
 @Injectable()
 export class TransactionRepository {
@@ -59,32 +57,6 @@ export class TransactionRepository {
     });
 
     return trades;
-  }
-
-  async createBuyOrder(orderRequest: OrderRequestDto, historyId: string) {
-    return await this.prisma.buyOrder.create({
-      data: {
-        historyId: historyId,
-        userId: orderRequest.userId,
-        coinCode: orderRequest.coinCode,
-        price: formatFixedPoint(orderRequest.price),
-        originalQuote: String(orderRequest.amount),
-        remainingQuote: String(orderRequest.amount),
-      },
-    });
-  }
-
-  async createSellOrder(orderRequest: OrderRequestDto, historyId: string) {
-    return await this.prisma.sellOrder.create({
-      data: {
-        historyId: historyId,
-        userId: orderRequest.userId,
-        coinCode: orderRequest.coinCode,
-        price: formatFixedPoint(orderRequest.price),
-        originalQuote: String(orderRequest.amount),
-        remainingBase: String(orderRequest.amount),
-      },
-    });
   }
 
   private getTableName(timeScale: TimeScale): string {

--- a/microservice/apps/transaction/src/transaction.service.ts
+++ b/microservice/apps/transaction/src/transaction.service.ts
@@ -6,7 +6,6 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { TransactionRepository } from './transaction.repository';
-import { OrderRequestDto } from '@app/grpc/dto/order.request.dto';
 import { OrderResponseDto } from '@app/grpc/dto/order.response.dto';
 import { GrpcOrderStatusCode } from '@app/common/enums/grpc-status.enum';
 import { OrderType } from '@app/common/enums/order-type.enum';
@@ -19,22 +18,12 @@ import { TradeGetResponseDto } from './dto/trade.get.response.dto';
 export class TransactionService {
   constructor(private transactionRepository: TransactionRepository) {}
 
-  async registerBuyOrder(orderRequest: OrderRequestDto, orderResponse: OrderResponseDto) {
+  async validateOrderResponse(orderResponse: OrderResponseDto) {
     if (orderResponse.status === GrpcOrderStatusCode.NO_BALANCE) {
       throw new BadRequestException('Not Enough Balance');
     } else if (orderResponse.status === GrpcOrderStatusCode.TRANSACTION_ERROR) {
       throw new InternalServerErrorException('Internal Server Transaction Error');
     }
-    await this.transactionRepository.createBuyOrder(orderRequest, orderResponse.historyId);
-  }
-
-  async registerSellOrder(orderRequest: OrderRequestDto, orderResponse: OrderResponseDto) {
-    if (orderResponse.status === GrpcOrderStatusCode.NO_BALANCE) {
-      throw new BadRequestException('Not Enough Balance');
-    } else if (orderResponse.status === GrpcOrderStatusCode.TRANSACTION_ERROR) {
-      throw new InternalServerErrorException('Internal Server Transaction Error');
-    }
-    await this.transactionRepository.createSellOrder(orderRequest, orderResponse.historyId);
   }
 
   async validateOrderOwnership(userId: string, historyId: string, orderType: OrderType) {

--- a/microservice/libs/grpc/proto/trade.proto
+++ b/microservice/libs/grpc/proto/trade.proto
@@ -15,16 +15,16 @@ message TradeRequest {
 message BuyerRequest {
   string userId = 1;
   string coinCode = 2;
-  double paymentAmount = 3;
-  double receivedCoins = 4;
-  double refund = 5;
+  string buyerPice = 3;
+  string tradePice = 4;
+  string receivedCoins = 5;
 }
 
 message SellerRequest {
   string userId = 1;
   string coinCode = 2;
-  double receivedAmount = 3;
-  double soldCoins = 4;
+  string tradePrice = 3;
+  string soldCoins = 4;
 }
 
 message TradeResponse {

--- a/microservice/libs/grpc/src/dto/trade.buyer.request.dto.ts
+++ b/microservice/libs/grpc/src/dto/trade.buyer.request.dto.ts
@@ -1,23 +1,21 @@
 export class TradeBuyerRequestDto {
   userId: string;
   coinCode: string;
-  remainingAmount: number;
-  paymentAmount: number;
-  receivedCoins: number;
-  refund: number;
+  buyerPice: string;
+  tradePice: string;
+  receivedCoins: string;
 
   constructor(
     userId: string,
     coinCode: string,
-    buyerPrice: number,
-    tradePrice: number,
-    quantity: number,
+    buyerPrice: string,
+    tradePrice: string,
+    quantity: string,
   ) {
     this.userId = userId;
     this.coinCode = coinCode;
-    const payment = tradePrice * quantity;
-    this.paymentAmount = payment;
+    this.buyerPice = buyerPrice;
+    this.tradePice = tradePrice;
     this.receivedCoins = quantity;
-    this.refund = buyerPrice * quantity - payment;
   }
 }

--- a/microservice/libs/grpc/src/dto/trade.order.dto.ts
+++ b/microservice/libs/grpc/src/dto/trade.order.dto.ts
@@ -1,0 +1,18 @@
+import { formatFixedPoint } from '@app/common/utils/number.format.util';
+import { OrderRequestDto } from './order.request.dto';
+
+export class TradeOrder {
+  historyId: string;
+  userId: string;
+  coinCode: string;
+  price: string;
+  originalQuote: number;
+
+  constructor(historyId: string, orderRequest: OrderRequestDto) {
+    this.historyId = historyId;
+    this.userId = orderRequest.userId;
+    this.coinCode = orderRequest.coinCode;
+    this.price = formatFixedPoint(orderRequest.price);
+    this.originalQuote = orderRequest.amount;
+  }
+}

--- a/microservice/libs/grpc/src/dto/trade.seller.request.dto.ts
+++ b/microservice/libs/grpc/src/dto/trade.seller.request.dto.ts
@@ -1,18 +1,18 @@
 export class TradeSellerRequestDto {
   userId: string;
-  receivedAmount: number;
   coinCode: string;
-  soldCoins: number;
+  tradePice: string;
+  soldCoins: string;
 
   constructor(
     userId: string,
     coinCode: string,
-    tradePrice: number,
-    quantity: number,
+    tradePrice: string,
+    quantity: string,
   ) {
     this.userId = userId;
     this.coinCode = coinCode;
-    this.receivedAmount = tradePrice * quantity;
+    this.tradePice = tradePrice;
     this.soldCoins = quantity;
   }
 }


### PR DESCRIPTION
## 📚 이슈 번호

## ✅ 작업 내용
- 매수 매도 주문 접수 시 buy_order, sell_order에 접수 되고 큐에 들어가고 있는 것을 체결 후에 남은 체결량만 buy_order, sell_order에 접수되도록 변경

## 🔥 트러블 슈팅
- processor에서 job.data를 넣어주고 있었는데 데이터를 넣을 떄 trade로 넣어주었기 때문에 job.data.trade로 넣어주어야만 했던 문제가 있었습니다.

## 🖋️ 학습 자료

## 🐝 비고